### PR TITLE
hotfix: last known possible cause

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,6 +13,7 @@ const app = express();
 
 app.use(cors());
 app.use(cookieParser());
+app.use(express.urlencoded({ extended: true }))
 app.use(bodyParser.json());
 app.use(limiter);
 app.use(fileUpload());


### PR DESCRIPTION
As of a few off site attempts, the addition of urlencoded in the express middleware is the last resort of the empty payload error.