### PR TITLE
hotfix: unstable 'pages' update database query for page.

### DIFF
--- a/src/services/pageService.js
+++ b/src/services/pageService.js
@@ -41,7 +41,7 @@ exports.updatePageSectionBySlug = async (slug, data) => {
     const htmlContent = await scraper.fetchPageContent(slug);
     if (!htmlContent) return null;
 
-    const sections = data.sections;
+    const sections = data?.sections;
 
     const updatedHtml = await scraper.htmlContentUpdate(
       htmlContent, sections,
@@ -50,7 +50,7 @@ exports.updatePageSectionBySlug = async (slug, data) => {
     const updatedPage = await scraper.updateScrapedData(
       slug, updatedHtml, sections,
     );
-    const formattedResult = formatPageSections(updatedPage.pageSections);
+    const formattedResult = formatPageSections(updatedPage?.pageSections);
 
     return formattedResult;
   } catch (error) {

--- a/src/utils/scraper.js
+++ b/src/utils/scraper.js
@@ -279,18 +279,20 @@ const updateScrapedData = async (slug, htmlContent, sections) => {
       ]);
 
       const res = await pool.runTransaction(`
-        INSERT INTO page_sections (page_id, section_key, content, updated_at)
-        VALUES ${values.map(() => '(?, ?, ?, ?)').join(', ')}
-        RETURNING
-          page_sections.page_id AS page_id,
-          pages.slug AS page_slug,
-          pages.title AS page_title,
-          page_sections.section_key AS sections_section_key,
-          page_sections.content AS sections_content,
-          page_sections.created_at AS sections_created_at,
-          page_sections.updated_at AS sections_updated_at
-        FROM pages
-        WHERE pages.id = page_sections.page_id
+        WITH inserted AS (
+          INSERT INTO page_sections (page_id, section_key, content, updated_at)
+          VALUES ${values.map(() => '(?, ?, ?, ?)').join(', ')}
+          RETURNING page_id, section_key, content, updated_at
+        )
+        SELECT
+          i.page_id,
+          i.section_key,
+          i.content,
+          i.updated_at,
+          p.slug AS page_slug,
+          p.title AS page_title
+        FROM inserted i
+        JOIN pages p ON p.id = i.page_id
       `, values.flat());
 
       updatedPageSections.push(...res.rows);


### PR DESCRIPTION
# Changes
- Using null-safe operator on pageService update method.
- Using WITH-INSERT-RETURNING-SELECT-FROM query instead of INSERT-RETURNING-FROM for inserting new values on 'pages' update if there is a new section.